### PR TITLE
New way of changing settings (code only)

### DIFF
--- a/EasePass/Controls/CopyPasswordbox.xaml.cs
+++ b/EasePass/Controls/CopyPasswordbox.xaml.cs
@@ -63,7 +63,7 @@ namespace EasePass.Controls
 
         private void TextBox_DoubleTapped(object sender, Microsoft.UI.Xaml.Input.DoubleTappedRoutedEventArgs e)
         {
-            if (AppSettings.GetSettingsAsBool(AppSettingsValues.doubleTapToCopy, DefaultSettingsValues.doubleTapToCopy))
+            if (SettingsManager.GetSettingsAsBool(AppSettingsValues.doubleTapToCopy, DefaultSettingsValues.doubleTapToCopy))
                 CopyText();
         }
         private void CopyText_Click(object sender, RoutedEventArgs e)

--- a/EasePass/Controls/CopyTextbox.xaml.cs
+++ b/EasePass/Controls/CopyTextbox.xaml.cs
@@ -52,7 +52,7 @@ namespace EasePass.Controls
 
         private void TextBox_DoubleTapped(object sender, Microsoft.UI.Xaml.Input.DoubleTappedRoutedEventArgs e)
         {
-            if (AppSettings.GetSettingsAsBool(AppSettingsValues.doubleTapToCopy, DefaultSettingsValues.doubleTapToCopy))
+            if (SettingsManager.GetSettingsAsBool(AppSettingsValues.doubleTapToCopy, DefaultSettingsValues.doubleTapToCopy))
                 CopyText_Click(this, null);
         }
     }

--- a/EasePass/Controls/EditPasswordBox.xaml.cs
+++ b/EasePass/Controls/EditPasswordBox.xaml.cs
@@ -45,7 +45,7 @@ namespace EasePass.Controls
 
         private void TextBox_DoubleTapped(object sender, Microsoft.UI.Xaml.Input.DoubleTappedRoutedEventArgs e)
         {
-            if (AppSettings.GetSettingsAsBool(AppSettingsValues.doubleTapToCopy, DefaultSettingsValues.doubleTapToCopy))
+            if (SettingsManager.GetSettingsAsBool(AppSettingsValues.doubleTapToCopy, DefaultSettingsValues.doubleTapToCopy))
                 CopyText();
         }
 

--- a/EasePass/Controls/PasswordSafetyChart.xaml.cs
+++ b/EasePass/Controls/PasswordSafetyChart.xaml.cs
@@ -99,7 +99,7 @@ namespace EasePass.Controls
         public void EvaluatePassword(string password, bool existingSingleTime = false)
         {
             checks[3] = null;
-            if (!AppSettings.GetSettingsAsBool(AppSettingsValues.disableLeakedPasswords, DefaultSettingsValues.disableLeakedPasswords))
+            if (!SettingsManager.GetSettingsAsBool(AppSettingsValues.disableLeakedPasswords, DefaultSettingsValues.disableLeakedPasswords))
             {
                 Task<bool?> task = PasswordHelper.IsPwned(password);
                 TaskAwaiter<bool?> taskAwaiter = task.GetAwaiter();

--- a/EasePass/Helper/AppVersionHelper.cs
+++ b/EasePass/Helper/AppVersionHelper.cs
@@ -25,8 +25,8 @@ namespace EasePass.Helper
     {
         private static bool IsOnNewVersion(string version)
         {
-            string lastSavedVersion = AppSettings.GetSettings(AppSettingsValues.appVersion);
-            AppSettings.SaveSettings(AppSettingsValues.appVersion, version);
+            string lastSavedVersion = AppSettings.AppVersion;
+            AppSettings.AppVersion = version;
 
             //no version saved -> first start
             if (lastSavedVersion.Length == 0)

--- a/EasePass/Helper/EncryptDecryptHelper.cs
+++ b/EasePass/Helper/EncryptDecryptHelper.cs
@@ -125,7 +125,7 @@ namespace EasePass.Helper
 
         private static byte[] GetCryptionKey(SecureString pw, string salt = "")
         {
-            byte[] saltFromDatabase = Encoding.UTF8.GetBytes(salt.Length == 0 ? AppSettings.GetSettings(AppSettingsValues.pSalt) : "");
+            byte[] saltFromDatabase = Encoding.UTF8.GetBytes(salt.Length == 0 ? SettingsManager.GetSettings(AppSettingsValues.pSalt) : "");
             int keySizeInBytes = 32;
             int iterations = 10000;
 

--- a/EasePass/Helper/InactivityHelper.cs
+++ b/EasePass/Helper/InactivityHelper.cs
@@ -44,7 +44,7 @@ namespace EasePass.Helper
 
         public void WindowDeactivated()
         {
-            inactivityTimer.Interval = new TimeSpan(0, AppSettings.GetSettingsAsInt(AppSettingsValues.inactivityLogoutTime, DefaultSettingsValues.inactivityLogoutTime), 0);
+            inactivityTimer.Interval = new TimeSpan(0, SettingsManager.GetSettingsAsInt(AppSettingsValues.inactivityLogoutTime, DefaultSettingsValues.inactivityLogoutTime), 0);
 
             inactivityTimer.Stop();
             inactivityTimer.Start();

--- a/EasePass/Helper/LocalizationHelper.cs
+++ b/EasePass/Helper/LocalizationHelper.cs
@@ -42,7 +42,7 @@ public class LocalizationHelper
         {
             Windows.Globalization.ApplicationLanguages.PrimaryLanguageOverride = languageItem.Tag;
 
-            AppSettings.SaveSettings(AppSettingsValues.language, languageItem.Tag);
+            SettingsManager.SaveSettings(AppSettingsValues.language, languageItem.Tag);
         }
     }
 
@@ -50,7 +50,7 @@ public class LocalizationHelper
     {
         RegisterLanguageFromResource();
 
-        var languageTag = AppSettings.GetSettings(AppSettingsValues.language, "en-US");
+        var languageTag = SettingsManager.GetSettings(AppSettingsValues.language, "en-US");
         var res = languages.Find(x => x.Tag == languageTag);
         if (res == null)
         {

--- a/EasePass/Helper/PasswordHelper.cs
+++ b/EasePass/Helper/PasswordHelper.cs
@@ -86,9 +86,9 @@ namespace EasePass.Helper
 
         public static async Task<string> GeneratePassword()
         {
-            disableLeakedPasswords = AppSettings.GetSettingsAsBool(AppSettingsValues.disableLeakedPasswords, DefaultSettingsValues.disableLeakedPasswords);
-            int length = AppSettings.GetSettingsAsInt(AppSettingsValues.passwordLength, DefaultSettingsValues.PasswordLength);
-            string chars = AppSettings.GetSettings(AppSettingsValues.passwordChars, DefaultSettingsValues.PasswordChars);         
+            disableLeakedPasswords = AppSettings.DisableLeakedPasswords;
+            int length = AppSettings.PasswordLength;
+            string chars = AppSettings.PasswordChars;         
             Random r = new Random();
 
             StringBuilder password = new StringBuilder();
@@ -132,7 +132,7 @@ namespace EasePass.Helper
 
             checks[0] = password.Any(char.IsLower);
             checks[1] = password.Any(char.IsUpper);
-            checks[2] = password.Length >= AppSettings.GetSettingsAsInt(AppSettingsValues.passwordLength, DefaultSettingsValues.PasswordLength);
+            checks[2] = password.Length >= AppSettings.PasswordLength;
             checks[3] = password.Any(char.IsPunctuation);
             checks[4] = password.Any(char.IsDigit);
             checks[5] = !ContainsCommonSequences(password);

--- a/EasePass/MainWindow.xaml.cs
+++ b/EasePass/MainWindow.xaml.cs
@@ -70,13 +70,12 @@ namespace EasePass
 
         private void RestoreSettings()
         {
-            var windowState = (OverlappedPresenterState)Enum.Parse(typeof(OverlappedPresenterState), AppSettings.GetSettings(AppSettingsValues.windowState, "2"));
-            WindowStateHelper.SetWindowState(this, windowState);
+            WindowStateHelper.SetWindowState(this, AppSettings.WindowState);
 
-            var width = AppSettings.GetSettingsAsInt(AppSettingsValues.windowWidth, 1100);
-            var height = AppSettings.GetSettingsAsInt(AppSettingsValues.windowHeight, 700);
-            var left = AppSettings.GetSettingsAsInt(AppSettingsValues.windowLeft, -5000);
-            var top = AppSettings.GetSettingsAsInt(AppSettingsValues.windowTop, -5000);
+            var width = AppSettings.WindowWidth; ;
+            var height = AppSettings.WindowHeight; 
+            var left = AppSettings.WindowLeft;
+            var top = AppSettings.WindowTop;
 
             //when closing the window from a minimized state the size will be wrong:
             if (width < 200)
@@ -113,11 +112,11 @@ namespace EasePass
         private void AppWindow_Closing(Microsoft.UI.Windowing.AppWindow sender, Microsoft.UI.Windowing.AppWindowClosingEventArgs args)
         {
             //save settings:
-            AppSettings.SaveSettings(AppSettingsValues.windowWidth, this.AppWindow.Size.Width);
-            AppSettings.SaveSettings(AppSettingsValues.windowHeight, this.AppWindow.Size.Height);
-            AppSettings.SaveSettings(AppSettingsValues.windowLeft, this.AppWindow.Position.X);
-            AppSettings.SaveSettings(AppSettingsValues.windowTop, this.AppWindow.Position.Y);
-            AppSettings.SaveSettings(AppSettingsValues.windowState, WindowStateHelper.GetWindowState(this));
+            AppSettings.WindowWidth = this.AppWindow.Size.Width;
+            AppSettings.WindowHeight = this.AppWindow.Size.Height;
+            AppSettings.WindowLeft = this.AppWindow.Position.X;
+            AppSettings.WindowTop = this.AppWindow.Position.Y;
+            AppSettings.WindowState = WindowStateHelper.GetWindowState(this);
         }
 
         private void NavigateBack_Click(object sender, RoutedEventArgs e)

--- a/EasePass/Models/Database.cs
+++ b/EasePass/Models/Database.cs
@@ -46,8 +46,8 @@ public class Database : IDisposable, INotifyPropertyChanged
         set
         {
             loadedInstance = value;
-            if(loadedInstance != null)
-                AppSettings.SaveSettings(AppSettingsValues.loadedDatabaseName, loadedInstance.Name);
+            if (loadedInstance != null)
+                AppSettings.LoadedDatabaseName = loadedInstance.Name;
 
             if (loadedInstance.PropertyChanged != null)
             {
@@ -87,7 +87,7 @@ public class Database : IDisposable, INotifyPropertyChanged
 
     public static string[] GetAllDatabasePaths()
     {
-        string paths = AppSettings.GetSettings(AppSettingsValues.databasePaths, DefaultSettingsValues.databasePaths);
+        string paths = AppSettings.DatabasePaths;
         ReadOnlySpan<char> chars = paths.AsSpan();
 
         int length = chars.Count('|') + 1;
@@ -113,7 +113,7 @@ public class Database : IDisposable, INotifyPropertyChanged
 
     public static void SetAllDatabasePaths(string paths)
     {
-        AppSettings.SaveSettings(AppSettingsValues.databasePaths, paths);
+        AppSettings.DatabasePaths = paths;
     }
 
     public static void AddDatabasePath(string path)

--- a/EasePass/Models/PasswordManagerItem.cs
+++ b/EasePass/Models/PasswordManagerItem.cs
@@ -137,13 +137,13 @@ namespace EasePass.Models
         [JsonIgnore]
         public string FirstChar = "";
         [JsonIgnore]
-        public bool ShowIcon => AppSettings.GetSettingsAsBool(AppSettingsValues.showIcons, DefaultSettingsValues.showIcons);
+        public bool ShowIcon =>  AppSettings.ShowIcons;
 
         public event PropertyChangedEventHandler PropertyChanged;
 
         public PasswordManagerItem()
         {
-            AppSettings.RegisterSettingsChangedEvent(AppSettingsValues.showIcons, (object o, string setting) =>
+            SettingsManager.RegisterSettingsChangedEvent(AppSettingsValues.showIcons, (object o, string setting) =>
             {
                 Website = _Website;
                 NotifyPropertyChanged("Website");

--- a/EasePass/Settings/AppSettings.cs
+++ b/EasePass/Settings/AppSettings.cs
@@ -88,12 +88,12 @@ public class AppSettings
     }
     public static string LoadedDatabaseName
     {
-        get => SettingsManager.GetSettings(AppSettingsValues.loadedDatabaseName);
+        get => SettingsManager.GetSettings(AppSettingsValues.loadedDatabaseName, null);
         set => SettingsManager.SaveSettings(AppSettingsValues.loadedDatabaseName, value);
     }
-    public static int clipboardClearTimeoutSec
+    public static int ClipboardClearTimeoutSec
     {
-        get => SettingsManager.GetSettingsAsInt(AppSettingsValues.loadedDatabaseName, DefaultSettingsValues.ClipboardClearTimeoutSec);
-        set => SettingsManager.SaveSettings(AppSettingsValues.loadedDatabaseName, value);
+        get => SettingsManager.GetSettingsAsInt(AppSettingsValues.clipboardClearTimeoutSec, DefaultSettingsValues.ClipboardClearTimeoutSec);
+        set => SettingsManager.SaveSettings(AppSettingsValues.clipboardClearTimeoutSec, value);
     }
 }

--- a/EasePass/Settings/AppSettings.cs
+++ b/EasePass/Settings/AppSettings.cs
@@ -1,59 +1,99 @@
-﻿/*
-MIT License
+﻿using Microsoft.UI.Windowing;
 
-Copyright (c) 2023 Julius Kirsch
+namespace EasePass.Settings;
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-*/
-
-using EasePass.Helper;
-using System;
-using System.Collections.Generic;
-using Windows.Storage;
-
-namespace EasePass.Settings
+public class AppSettings
 {
-    internal class AppSettings
+    public static string Language
     {
-        private static Dictionary<string, EventHandler<string>> events = new Dictionary<string, EventHandler<string>>();
-        public static void RegisterSettingsChangedEvent(string Value, EventHandler<string> eventHandler)
-        {
-            if (events.ContainsKey(Value)) events[Value] += eventHandler;
-            else events.Add(Value, eventHandler);
-        }
+        get => SettingsManager.GetSettings(AppSettingsValues.language, DefaultSettingsValues.defaultLanguage);
+        set => SettingsManager.SaveSettings(AppSettingsValues.language, value);
+    }
 
-        public static void SaveSettings(string Value, object data)
-        {
-            if (data == null)
-                return;
+    public static string PasswordSalt
+    {
+        get => SettingsManager.GetSettings(AppSettingsValues.pSalt);
+        set => SettingsManager.SaveSettings(AppSettingsValues.pSalt, value);
+    }
+    public static int WindowWidth
+    {
+        get => SettingsManager.GetSettingsAsInt(AppSettingsValues.windowWidth, DefaultSettingsValues.windowWidth);
+        set => SettingsManager.SaveSettings(AppSettingsValues.windowWidth, value);
+    }
+    public static int WindowHeight
+    {
+        get => SettingsManager.GetSettingsAsInt(AppSettingsValues.windowHeight, DefaultSettingsValues.windowHeight);
+        set => SettingsManager.SaveSettings(AppSettingsValues.windowHeight, value);
+    }
+    public static int WindowLeft
+    {
+        get => SettingsManager.GetSettingsAsInt(AppSettingsValues.windowLeft, DefaultSettingsValues.windowLeft);
+        set => SettingsManager.SaveSettings(AppSettingsValues.windowLeft, value);
+    }
+    public static int WindowTop
+    {
+        get => SettingsManager.GetSettingsAsInt(AppSettingsValues.windowTop, DefaultSettingsValues.windowTop);
+        set => SettingsManager.SaveSettings(AppSettingsValues.windowTop, value);
+    }
+    public static int PasswordLength
+    {
+        get => SettingsManager.GetSettingsAsInt(AppSettingsValues.passwordLength, DefaultSettingsValues.passwordLength);
+        set => SettingsManager.SaveSettings(AppSettingsValues.passwordLength, value);
+    }
+    public static string PasswordChars
+    {
+        get => SettingsManager.GetSettings(AppSettingsValues.passwordChars, DefaultSettingsValues.passwordChars);
+        set => SettingsManager.SaveSettings(AppSettingsValues.passwordChars, value);
+    }
+    public static int InactivityLogoutTime
+    {
+        get => SettingsManager.GetSettingsAsInt(AppSettingsValues.inactivityLogoutTime, DefaultSettingsValues.inactivityLogoutTime);
+        set => SettingsManager.SaveSettings(AppSettingsValues.inactivityLogoutTime, value);
+    }
+    public static bool DoubleTapToCopy
+    {
+        get => SettingsManager.GetSettingsAsBool(AppSettingsValues.doubleTapToCopy, DefaultSettingsValues.doubleTapToCopy);
+        set => SettingsManager.SaveSettings(AppSettingsValues.doubleTapToCopy, value);
+    }
 
-            //cancel if data is a type
-            if (data.ToString() == data.GetType().Name)
-                return;
-
-            ApplicationData.Current.LocalSettings.Values[Value] = data.ToString();
-
-            if (events.TryGetValue(Value, out EventHandler<string> value) && value != null) value(null, Value);
-        }
-        public static string GetSettings(string value, string defaultValue = "")
-        {
-            return ApplicationData.Current.LocalSettings.Values[value] as string ?? defaultValue;
-        }
-        public static int GetSettingsAsInt(string value, int defaultValue = 0)
-        {
-            return ConvertHelper.ToInt(ApplicationData.Current.LocalSettings.Values[value] as string, defaultValue);
-        }
-        public static bool GetSettingsAsBool(string value, bool defaultValue = false)
-        {
-            return ConvertHelper.ToBoolean(ApplicationData.Current.LocalSettings.Values[value] as string, defaultValue);
-        }
+    public static bool ShowIcons
+    {
+        get => SettingsManager.GetSettingsAsBool(AppSettingsValues.showIcons, DefaultSettingsValues.showIcons);
+        set => SettingsManager.SaveSettings(AppSettingsValues.showIcons, value);
+    }
+    public static bool DisableLeakedPasswords
+    {
+        get => SettingsManager.GetSettingsAsBool(AppSettingsValues.disableLeakedPasswords, DefaultSettingsValues.disableLeakedPasswords);
+        set => SettingsManager.SaveSettings(AppSettingsValues.disableLeakedPasswords, value);
+    }
+    public static OverlappedPresenterState WindowState
+    {
+        get => (OverlappedPresenterState)SettingsManager.GetSettingsAsInt(AppSettingsValues.windowState, 2);
+        set => SettingsManager.SaveSettings(AppSettingsValues.windowState, value);
+    }
+    public static string AppVersion
+    {
+        get => SettingsManager.GetSettings(AppSettingsValues.appVersion);
+        set => SettingsManager.SaveSettings(AppSettingsValues.appVersion, value);
+    }
+    public static int GridSplitterWidth
+    {
+        get => SettingsManager.GetSettingsAsInt(AppSettingsValues.gridSplitterWidth, DefaultSettingsValues.gridSplitterWidth);
+        set => SettingsManager.SaveSettings(AppSettingsValues.gridSplitterWidth, value);
+    }
+    public static string DatabasePaths
+    {
+        get => SettingsManager.GetSettings(AppSettingsValues.databasePaths, DefaultSettingsValues.databasePaths);
+        set => SettingsManager.SaveSettings(AppSettingsValues.databasePaths, value);
+    }
+    public static string LoadedDatabaseName
+    {
+        get => SettingsManager.GetSettings(AppSettingsValues.loadedDatabaseName);
+        set => SettingsManager.SaveSettings(AppSettingsValues.loadedDatabaseName, value);
+    }
+    public static int clipboardClearTimeoutSec
+    {
+        get => SettingsManager.GetSettingsAsInt(AppSettingsValues.loadedDatabaseName, DefaultSettingsValues.ClipboardClearTimeoutSec);
+        set => SettingsManager.SaveSettings(AppSettingsValues.loadedDatabaseName, value);
     }
 }

--- a/EasePass/Settings/AppSettingsValues.cs
+++ b/EasePass/Settings/AppSettingsValues.cs
@@ -33,7 +33,6 @@ namespace EasePass.Settings
         public const string windowState = "windowState";
         public const string appVersion = "appVersion";
         public const string gridSplitterWidth = "gridSplitterWidth";
-        public const string lastBackupDay = "lastBackupDay";
         public const string databasePaths = "databasePaths";
         public const string loadedDatabaseName = "loadedDatabaseName";
         public const string clipboardClearTimeoutSec = "clipboardClearTimeoutSec";

--- a/EasePass/Settings/DefaultSettingsValues.cs
+++ b/EasePass/Settings/DefaultSettingsValues.cs
@@ -20,9 +20,8 @@ namespace EasePass.Settings
 {
     internal static class DefaultSettingsValues
     {
-        public const int InactivityLogoutTime = 3; //Minutes
-        public const string PasswordChars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890!\"§$%&/()=?*+'#-_.:,;<>";
-        public const int PasswordLength = 15;
+        public const string passwordChars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890!\"§$%&/()=?*+'#-_.:,;<>";
+        public const int passwordLength = 15;
         public const int inactivityLogoutTime = 3; //Minutes
         public const bool doubleTapToCopy = true;
         public const bool showIcons = true;
@@ -30,5 +29,11 @@ namespace EasePass.Settings
         public static readonly string databasePaths = System.IO.Path.Combine(ApplicationData.Current.LocalFolder.Path, "easepass.epdb") + "|";
         public static string defaultLanguage = "en-US";
         public const int ClipboardClearTimeoutSec = 15;
+        public const int gridSplitterWidth = 240;
+
+        public const int windowWidth = 1100;
+        public const int windowHeight = 700;
+        public const int windowLeft = -5000;
+        public const int windowTop = -5000;
     }
 }

--- a/EasePass/Settings/SettingsManager.cs
+++ b/EasePass/Settings/SettingsManager.cs
@@ -1,0 +1,59 @@
+﻿/*
+MIT License
+
+Copyright (c) 2023 Julius Kirsch
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+*/
+
+using EasePass.Helper;
+using System;
+using System.Collections.Generic;
+using Windows.Storage;
+
+namespace EasePass.Settings
+{
+    internal class SettingsManager
+    {
+        private static Dictionary<string, EventHandler<string>> events = new Dictionary<string, EventHandler<string>>();
+        public static void RegisterSettingsChangedEvent(string Value, EventHandler<string> eventHandler)
+        {
+            if (events.ContainsKey(Value)) events[Value] += eventHandler;
+            else events.Add(Value, eventHandler);
+        }
+
+        public static void SaveSettings(string Value, object data)
+        {
+            if (data == null)
+                return;
+
+            //cancel if data is a type
+            if (data.ToString() == data.GetType().Name)
+                return;
+
+            ApplicationData.Current.LocalSettings.Values[Value] = data.ToString();
+
+            if (events.TryGetValue(Value, out EventHandler<string> value) && value != null) value(null, Value);
+        }
+        public static string GetSettings(string value, string defaultValue = "")
+        {
+            return ApplicationData.Current.LocalSettings.Values[value] as string ?? defaultValue;
+        }
+        public static int GetSettingsAsInt(string value, int defaultValue = 0)
+        {
+            return ConvertHelper.ToInt(ApplicationData.Current.LocalSettings.Values[value] as string, defaultValue);
+        }
+        public static bool GetSettingsAsBool(string value, bool defaultValue = false)
+        {
+            return ConvertHelper.ToBoolean(ApplicationData.Current.LocalSettings.Values[value] as string, defaultValue);
+        }
+    }
+}

--- a/EasePass/Views/LoginPage.xaml.cs
+++ b/EasePass/Views/LoginPage.xaml.cs
@@ -39,7 +39,7 @@ namespace EasePass.Views
             base.OnNavigatedTo(e);
 
             var databases = Database.GetAllUnloadedDatabases();
-            var comboboxIndexDBName = AppSettings.GetSettings(AppSettingsValues.loadedDatabaseName, databases.Length > 0 ? databases[0].Name : "");
+            var comboboxIndexDBName = AppSettings.LoadedDatabaseName ?? (databases.Length > 0 ? databases[0].Name : ""); //double check here for correct null check
             foreach (var item in databases)
             {
                 databasebox.Items.Add(item);
@@ -49,8 +49,7 @@ namespace EasePass.Views
                 }
             }
 
-            var lang = AppSettings.GetSettings(AppSettingsValues.language, "en-US");
-            string tip = await DailyTipHelper.GetTodaysTip(lang);
+            string tip = await DailyTipHelper.GetTodaysTip(AppSettings.Language);
             if (string.IsNullOrEmpty(tip))
                 return;
 
@@ -111,7 +110,7 @@ namespace EasePass.Views
             if (databasebox.SelectedItem == null)
                 return;
 
-            AppSettings.SaveSettings(AppSettingsValues.loadedDatabaseName, (databasebox.SelectedItem as Database).Name);
+            AppSettings.LoadedDatabaseName = (databasebox.SelectedItem as Database).Name;
         }
 
         private async void ImportDatabase_Click(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)

--- a/EasePass/Views/PasswordsPage.xaml.cs
+++ b/EasePass/Views/PasswordsPage.xaml.cs
@@ -71,7 +71,7 @@ namespace EasePass.Views
                 AppVersionHelper.CheckNewVersion();
 
                 //load the gridsplittervalue back
-                gridSplitterLoadSize.Width = new GridLength(AppSettings.GetSettingsAsInt(AppSettingsValues.gridSplitterWidth, 240), GridUnitType.Pixel);
+                gridSplitterLoadSize.Width = new GridLength(AppSettings.GridSplitterWidth, GridUnitType.Pixel);
             }
 
             if (Database.LoadedInstance != null)
@@ -225,7 +225,7 @@ namespace EasePass.Views
         }
         private void StoreGridSplitterValue()
         {
-            AppSettings.SaveSettings(AppSettingsValues.gridSplitterWidth, gridSplitterLoadSize.Width);
+            AppSettings.GridSplitterWidth = (int)gridSplitterLoadSize.Width.Value;
         }
 
         private void M_window_Closed(object sender, WindowEventArgs args)

--- a/EasePass/Views/RegisterPage.xaml.cs
+++ b/EasePass/Views/RegisterPage.xaml.cs
@@ -71,7 +71,7 @@ namespace EasePass.Views
             if (res == null)
                 return;
 
-            AppSettings.SaveSettings(AppSettingsValues.loadedDatabaseName, res.Name);
+            SettingsManager.SaveSettings(AppSettingsValues.loadedDatabaseName, res.Name);
 
             App.m_frame.Navigate(typeof(LoginPage));
         }

--- a/EasePass/Views/SettingsPage.xaml.cs
+++ b/EasePass/Views/SettingsPage.xaml.cs
@@ -24,6 +24,7 @@ using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Navigation;
 using System;
 using System.Collections.ObjectModel;
+using System.Linq;
 using System.Security;
 using System.Text;
 
@@ -44,17 +45,17 @@ namespace EasePass.Views
         {
             blockEventsOnloadSettings = true;
 
-            inactivityLogoutTime.Value = AppSettings.GetSettingsAsInt(AppSettingsValues.inactivityLogoutTime, DefaultSettingsValues.inactivityLogoutTime);
-            doubleTapToCopySW.IsOn = AppSettings.GetSettingsAsBool(AppSettingsValues.doubleTapToCopy, DefaultSettingsValues.doubleTapToCopy);
-            showIcons.IsOn = AppSettings.GetSettingsAsBool(AppSettingsValues.showIcons, DefaultSettingsValues.showIcons);
-            pswd_chars.Text = AppSettings.GetSettings(AppSettingsValues.passwordChars, DefaultSettingsValues.PasswordChars);
-            pswd_length.Text = Convert.ToString(AppSettings.GetSettingsAsInt(AppSettingsValues.passwordLength, DefaultSettingsValues.PasswordLength));
-            disableLeakedPasswords.IsOn = !AppSettings.GetSettingsAsBool(AppSettingsValues.disableLeakedPasswords, DefaultSettingsValues.disableLeakedPasswords);
-            clipboardClearTimeout.Value = AppSettings.GetSettingsAsInt(AppSettingsValues.clipboardClearTimeoutSec, DefaultSettingsValues.ClipboardClearTimeoutSec);
+            inactivityLogoutTime.Value = AppSettings.InactivityLogoutTime;
+            doubleTapToCopySW.IsOn = AppSettings.DoubleTapToCopy;
+            showIcons.IsOn = AppSettings.ShowIcons;
+            pswd_chars.Text = AppSettings.PasswordChars;
+            pswd_length.Text = AppSettings.PasswordLength.ToString();
+            disableLeakedPasswords.IsOn = !AppSettings.DisableLeakedPasswords;
+            clipboardClearTimeout.Value = AppSettings.clipboardClearTimeoutSec;
 
             selectLanguageBox.ItemsSource = MainWindow.localizationHelper.languages;
 
-            var languageTag = AppSettings.GetSettings(AppSettingsValues.language, DefaultSettingsValues.defaultLanguage);
+            var languageTag = AppSettings.Language;
             selectLanguageBox.SelectedIndex = MainWindow.localizationHelper.languages.FindIndex(x => x.Tag == languageTag);
             blockEventsOnloadSettings = false;
         }
@@ -92,7 +93,7 @@ namespace EasePass.Views
             if (blockEventsOnloadSettings)
                 return;
 
-            AppSettings.SaveSettings(AppSettingsValues.inactivityLogoutTime, inactivityLogoutTime.Value);
+            AppSettings.InactivityLogoutTime = (int)inactivityLogoutTime.Value;
         }
 
         private void DoubleTapToCopySW_Toggled(object sender, RoutedEventArgs e)
@@ -100,15 +101,15 @@ namespace EasePass.Views
             if (blockEventsOnloadSettings)
                 return;
 
-            AppSettings.SaveSettings(AppSettingsValues.doubleTapToCopy, doubleTapToCopySW.IsOn);
+            AppSettings.DoubleTapToCopy = doubleTapToCopySW.IsOn;
         }
 
         private void showIcons_Toggled(object sender, RoutedEventArgs e)
         {
             if (blockEventsOnloadSettings)
                 return;
-
-            AppSettings.SaveSettings(AppSettingsValues.showIcons, showIcons.IsOn);
+            
+            AppSettings.ShowIcons = showIcons.IsOn;
             if (passwordsPage != null)
                 passwordsPage.Reload();
         }
@@ -136,10 +137,10 @@ namespace EasePass.Views
 
             if (pswd_length.Text.Length == 0 || pswd_length.Text == "0")
             {
-                AppSettings.SaveSettings(AppSettingsValues.passwordLength, DefaultSettingsValues.PasswordLength);
+                AppSettings.PasswordLength = DefaultSettingsValues.passwordLength;
                 return;
             }
-            AppSettings.SaveSettings(AppSettingsValues.passwordLength, Math.Max(ConvertHelper.ToInt(pswd_length.Text, DefaultSettingsValues.PasswordLength), 8));
+            AppSettings.PasswordLength = Math.Max(ConvertHelper.ToInt(pswd_length.Text, DefaultSettingsValues.passwordLength), 8);
         }
 
         private void pswd_chars_TextChanged(object sender, TextChangedEventArgs e)
@@ -147,16 +148,16 @@ namespace EasePass.Views
             if (blockEventsOnloadSettings)
                 return;
 
-            AppSettings.SaveSettings(AppSettingsValues.passwordChars,
-                pswd_chars.Text.Length == 0 ? DefaultSettingsValues.PasswordChars : pswd_chars.Text
-                );
+            AppSettings.PasswordChars =
+                pswd_chars.Text.Length == 0 ? DefaultSettingsValues.passwordChars : pswd_chars.Text;
         }
 
         private void disableLeakedPasswords_Toggled(object sender, RoutedEventArgs e)
         {
             if (blockEventsOnloadSettings)
                 return;
-            AppSettings.SaveSettings(AppSettingsValues.disableLeakedPasswords, !disableLeakedPasswords.IsOn);
+
+            AppSettings.DisableLeakedPasswords = !disableLeakedPasswords.IsOn;
         }
 
         private async void ImportPassword_Click(object sender, RoutedEventArgs e)
@@ -221,14 +222,14 @@ namespace EasePass.Views
             if (blockEventsOnloadSettings || selectLanguageBox.SelectedItem == null)
                 return;
 
-            AppSettings.SaveSettings(AppSettingsValues.language, (selectLanguageBox.SelectedItem as LanguageItem).Tag);
+            AppSettings.Language = (selectLanguageBox.SelectedItem as LanguageItem).Tag;
 
             MainWindow.localizationHelper.SetLanguage(selectLanguageBox.SelectedItem as LanguageItem);
         }
 
         private void clipboardClearTimeout_ValueChanged(NumberBox sender, NumberBoxValueChangedEventArgs args)
         {
-            AppSettings.SaveSettings(AppSettingsValues.clipboardClearTimeoutSec, clipboardClearTimeout.Value);
+            AppSettings.clipboardClearTimeoutSec = (int)clipboardClearTimeout.Value;
         }
     }
 }

--- a/EasePass/Views/SettingsPage.xaml.cs
+++ b/EasePass/Views/SettingsPage.xaml.cs
@@ -51,7 +51,7 @@ namespace EasePass.Views
             pswd_chars.Text = AppSettings.PasswordChars;
             pswd_length.Text = AppSettings.PasswordLength.ToString();
             disableLeakedPasswords.IsOn = !AppSettings.DisableLeakedPasswords;
-            clipboardClearTimeout.Value = AppSettings.clipboardClearTimeoutSec;
+            clipboardClearTimeout.Value = AppSettings.ClipboardClearTimeoutSec;
 
             selectLanguageBox.ItemsSource = MainWindow.localizationHelper.languages;
 
@@ -229,7 +229,7 @@ namespace EasePass.Views
 
         private void clipboardClearTimeout_ValueChanged(NumberBox sender, NumberBoxValueChangedEventArgs args)
         {
-            AppSettings.clipboardClearTimeoutSec = (int)clipboardClearTimeout.Value;
+            AppSettings.ClipboardClearTimeoutSec = (int)clipboardClearTimeout.Value;
         }
     }
 }


### PR DESCRIPTION
This change has nothing to do with how the app works or handles saving. 
It's just a simpler way for us to write the code to save and retrieve app settings.

Instead of writing:

`SettingsManager.GetSettings(AppSettingsValues.passwordChars, DefaultSettingsValues.passwordChars)`

We now can write 
`AppSettings.PasswordChars = "xyz"` 

and 

`string variable = AppSettings.PasswordChars;`