### PR TITLE
Performance Improve Password Generator

### DIFF
--- a/EasePass/Helper/PasswordHelper.cs
+++ b/EasePass/Helper/PasswordHelper.cs
@@ -28,8 +28,10 @@ namespace EasePass.Helper
 {
     public static class PasswordHelper
     {
+        /// <summary>
+        /// Specifies if it should be checked if the Password has been leaked
+        /// </summary>
         private static bool disableLeakedPasswords = false;
-
         private const string ABC = "abcdefghijklmnopqrstuvwxyz";
         private const int StringMinRepeat = 5;
         private const int IntegerMinRepeat = 4;
@@ -83,6 +85,10 @@ namespace EasePass.Helper
             }
         }
 
+        /// <summary>
+        /// Generates a new Password
+        /// </summary>
+        /// <returns>Returns the generated Password</returns>
         public static async Task<string> GeneratePassword()
         {
             disableLeakedPasswords = AppSettings.DisableLeakedPasswords;
@@ -108,6 +114,13 @@ namespace EasePass.Helper
             return password.ToString();
         }
 
+        /// <summary>
+        /// Validates if the given <paramref name="password"/> is Secure
+        /// </summary>
+        /// <param name="chars">The allowed Characters inside the Password</param>
+        /// <param name="length">The Length, which the Password should have</param>
+        /// <param name="password">The Password</param>
+        /// <returns>Returns <see langword="true"/> if the Password is Secure</returns>
         private static bool IsSecure(ReadOnlySpan<char> chars, int length, ReadOnlySpan<char> password)
         {
             int maxpoints = 2 + GetMaxPoints(chars); // 1 because of length + common sequences
@@ -121,14 +134,16 @@ namespace EasePass.Helper
             {
                 securepoints++;
             }
-            if (securepoints + 1 < Math.Min(maxpoints, length))
-                return false; // Skip Request if not necessary
-            
-            
-
             return securepoints == Math.Min(maxpoints, length);
         }
 
+        /// <summary>
+        /// Gets the Amount of Points of the current String
+        /// One point is awarded for each criterion met
+        /// Criterion: Digit, Lower, Upper, Punction
+        /// </summary>
+        /// <param name="chars">The String, which will be rated</param>
+        /// <returns>Returns the Points of the String.</returns>
         private static int GetMaxPoints(ReadOnlySpan<char> chars)
         {
             int maxpoints = 0;
@@ -186,7 +201,8 @@ namespace EasePass.Helper
             int length = CommonSequences.Count;
             for (int i = 0; i < length; i++)
             {
-                if (CommonSequences[i].ContainsSequence(password)) return true;
+                if (CommonSequences[i].ContainsSequence(password))
+                    return true;
             }
             return false;
         }
@@ -209,9 +225,8 @@ namespace EasePass.Helper
                 using (var data = await client.GetAsync("https://api.pwnedpasswords.com/range/" + hashPrefix))
                 {
                     if (data == null)
-                    {
                         return null;
-                    }
+
                     return ReadIsPwnedData(data, hashSuffix);
                 }
             }
@@ -240,9 +255,7 @@ namespace EasePass.Helper
                     var numberOfTimesPasswordPwned = int.Parse(splitLIne[1]);
 
                     if (lineHashedSuffix == hashSuffix)
-                    {
                         return true;
-                    }
                 }
             }
             return false;
@@ -255,9 +268,7 @@ namespace EasePass.Helper
                 byte[] inputBytes = Encoding.UTF8.GetBytes(input);
                 byte[] hashBytes = sha1.ComputeHash(inputBytes);
 
-                string hashHex = BitConverter.ToString(hashBytes).Replace("-", "").ToLower();
-
-                return hashHex;
+                return BitConverter.ToString(hashBytes).Replace("-", "").ToLower();
             }
         }
     }

--- a/EasePass/Helper/PasswordHelper.cs
+++ b/EasePass/Helper/PasswordHelper.cs
@@ -124,6 +124,8 @@ namespace EasePass.Helper
             if (securepoints + 1 < Math.Min(maxpoints, length))
                 return false; // Skip Request if not necessary
             
+            
+
             return securepoints == Math.Min(maxpoints, length);
         }
 
@@ -139,18 +141,22 @@ namespace EasePass.Helper
             {
                 if (!digit && char.IsDigit(chars[i]))
                 {
+                    digit = true;
                     maxpoints++;
                 }
                 else if (!lower && char.IsLower(chars[i]))
                 {
+                    lower = true;
                     maxpoints++;
                 }
                 else if (!upper && char.IsUpper(chars[i]))
                 {
+                    upper = true;
                     maxpoints++;
                 }
                 else if (!punctation && char.IsPunctuation(chars[i]))
                 {
+                    punctation = true;
                     maxpoints++;
                 }
                 else if (digit && lower && upper && punctation)

--- a/EasePass/Models/CommonPasswordSequence.cs
+++ b/EasePass/Models/CommonPasswordSequence.cs
@@ -1,4 +1,6 @@
-﻿namespace EasePass.Models;
+﻿using System;
+
+namespace EasePass.Models;
 
 public class CommonPasswordSequence
 {
@@ -19,15 +21,15 @@ public class CommonPasswordSequence
         entireSequence = true;
     }
 
-    public bool ContainsSequence(string str)
+    public bool ContainsSequence(ReadOnlySpan<char> str)
     {
-        string lower = str.ToLower();
-        if (entireSequence || sequence.Length <= minLength) 
-            return lower.Contains(sequence);
+
+        if (entireSequence || sequence.Length <= minLength)
+            return str.Contains(sequence, StringComparison.OrdinalIgnoreCase);
 
         for (int i = 0; i < sequence.Length - minLength; i++)
         {
-            if (lower.Contains(sequence.Substring(i, minLength))) 
+            if (str.Contains(sequence.AsSpan(i, minLength), StringComparison.OrdinalIgnoreCase))
                 return true;
         }
         return false;


### PR DESCRIPTION
Added Performance Improvements for the Password generator

- Created new Method which counts how many Criterion a String met (max. 4). This change has been made to reduce the amount of iterating of the same characters over and over to check each Criterion once per iteration and not all at the same time.
- Changed the way of the occurence of the Common Sequences will be checked. Before a String has been lowered all the time which was very expensive. Now it won't be lowered anymore instead the Contains will now ignore the Case which is way faster.
- The way the Password will be checked if it has been leaked has changed. The Implementation has requested many times if the Password has been leaked before the Password has been completly generated. Now it will check it at the end and will create a new Password if the generated one has been leaked (Much faster)
- Added Do While loops instead of While loops (won't be a huge improvement) sinve we have to go through at least one time we do not have to check the Condition in first place.
- Changed the type of the Password to a Span because iterating over a Span is slightly faster than a String

I think that was every improve
I also added some Documentation
