### PR TITLE
Performance Improvement for the removing a Database from the Paths #135

### DIFF
--- a/EasePass/Core/Database/Database.cs
+++ b/EasePass/Core/Database/Database.cs
@@ -112,17 +112,30 @@ public class Database
     }
     public static void RemoveDatabasePath(string path)
     {
-        List<string> paths = new List<string>();
-        paths.AddRange(GetAllDatabasePaths());
-        for (int i = 0; i < paths.Count; i++)
+        string[] paths = GetAllDatabasePaths();
+        if (paths == default || paths.Length == 0)
         {
-            if (paths[i].Equals(path, StringComparison.OrdinalIgnoreCase))
+            SetAllDatabasePaths(string.Empty);
+            return;
+        }
+
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < paths.Length; i++)
+        {
+            if (!paths[i].Equals(path, StringComparison.OrdinalIgnoreCase))
             {
-                paths.RemoveAt(i);
-                i--;
+                sb.Append(paths[i]);
+                sb.Append('|');
             }
         }
-        SetAllDatabasePaths(string.Join('|', paths));
+
+        if (sb.Length <= 0)
+        {
+            SetAllDatabasePaths(string.Empty);
+            return;
+        }
+        sb.Remove(sb.Length - 1, 1);
+        SetAllDatabasePaths(sb.ToString());
     }
     public static DatabaseItem[] GetAllUnloadedDatabases()
     {


### PR DESCRIPTION
Removed the use of a List.
Now it will only use the array for iterating (arrays are most of the time faster for iterating because they have a fixed block of pointers and the List have Pointers everywhere)
Added StringBuilder to Build the Path string. Since we do not use a List Anymore we have to get our new path differently because we can not remove elements of an Array to use a Join. By that I added the StringBuilder which allows to add multiple string that do not cause allocation that much.

I had to remove the last '|' (last char in the string) if I won't do that the Result won't be equal to the old implementation
I also added more checks to prevent errors or to do not needed work